### PR TITLE
Add ID, motifs, and motif counts to VCF

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -197,6 +197,7 @@ mod tests {
                 chrom: "chr1".to_string(),
                 start: 1,
                 end: 100,
+                id: "".to_string(),
             },
         );
         println!("Consensus: {}", cons.seq.unwrap());

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -198,6 +198,7 @@ mod tests {
                 start: 1,
                 end: 100,
                 id: "".to_string(),
+                motifs: "CA".to_string(),
             },
         );
         println!("Consensus: {}", cons.seq.unwrap());

--- a/src/genotype.rs
+++ b/src/genotype.rs
@@ -330,6 +330,7 @@ mod tests {
             chrom: String::from("chr7"),
             start: 154654404,
             end: 154654432,
+            id: String::from("test-repeat"),
         };
         let flanking = 2000;
         let minlen = 5;
@@ -369,6 +370,7 @@ mod tests {
             chrom: String::from("chr7"),
             start: 154654404,
             end: 154654432,
+            id: "TEST".to_string(),
         };
         let args = Cli {
             bam: String::from("test_data/small-test-phased.bam"),
@@ -397,6 +399,7 @@ mod tests {
             chrom: String::from("chr7"),
             start: 154654404,
             end: 154654432,
+            id: "TEST".to_string(),
         };
         let args = Cli {
             bam: String::from("test_data/small-test-phased.bam"),
@@ -441,6 +444,7 @@ mod tests {
             chrom: String::from("chr7"),
             start: 154654404,
             end: 154654432,
+            id: "TEST".to_string(),
         };
         let mut bam = parse_bam::create_bam_reader(&args.bam, &args.fasta);
         let genotype = genotype_repeat(&repeat, &args, &mut bam);
@@ -469,6 +473,7 @@ mod tests {
             chrom: String::from("chr7"),
             start: 154654404,
             end: 154654432,
+            id: "TEST".to_string(),
         };
         let mut bam = parse_bam::create_bam_reader(&args.bam, &args.fasta);
         let genotype = genotype_repeat(&repeat, &args, &mut bam);
@@ -498,6 +503,7 @@ mod tests {
             chrom: String::from("chr7"),
             start: 154654404,
             end: 154654432,
+            id: "TEST".to_string(),
         };
         let mut bam = parse_bam::create_bam_reader(&args.bam, &args.fasta);
         let genotype = genotype_repeat(&repeat, &args, &mut bam);

--- a/src/genotype.rs
+++ b/src/genotype.rs
@@ -331,6 +331,7 @@ mod tests {
             start: 154654404,
             end: 154654432,
             id: String::from("test-repeat"),
+            motifs: "CA".to_string(),
         };
         let flanking = 2000;
         let minlen = 5;
@@ -371,6 +372,7 @@ mod tests {
             start: 154654404,
             end: 154654432,
             id: "TEST".to_string(),
+            motifs: "CA".to_string(),
         };
         let args = Cli {
             bam: String::from("test_data/small-test-phased.bam"),
@@ -400,6 +402,7 @@ mod tests {
             start: 154654404,
             end: 154654432,
             id: "TEST".to_string(),
+            motifs: "CA".to_string(),
         };
         let args = Cli {
             bam: String::from("test_data/small-test-phased.bam"),
@@ -445,6 +448,7 @@ mod tests {
             start: 154654404,
             end: 154654432,
             id: "TEST".to_string(),
+            motifs: "CA".to_string(),
         };
         let mut bam = parse_bam::create_bam_reader(&args.bam, &args.fasta);
         let genotype = genotype_repeat(&repeat, &args, &mut bam);
@@ -474,6 +478,7 @@ mod tests {
             start: 154654404,
             end: 154654432,
             id: "TEST".to_string(),
+            motifs: "CA".to_string(),
         };
         let mut bam = parse_bam::create_bam_reader(&args.bam, &args.fasta);
         let genotype = genotype_repeat(&repeat, &args, &mut bam);
@@ -504,6 +509,7 @@ mod tests {
             start: 154654404,
             end: 154654432,
             id: "TEST".to_string(),
+            motifs: "CA".to_string(),
         };
         let mut bam = parse_bam::create_bam_reader(&args.bam, &args.fasta);
         let genotype = genotype_repeat(&repeat, &args, &mut bam);

--- a/src/motif.rs
+++ b/src/motif.rs
@@ -6,19 +6,18 @@ fn create_motif(seq: &str) -> String {
 }
 
 pub fn create_mc(motifs_string: &str, repeats: &str) -> String {
-    let motifs: Vec<String> = motifs_string.split(',').map(|s| s.to_string()).collect();
+     let motifs: Vec<String> = motifs_string.split(',').map(|s| s.to_string()).collect();
 
-    let mut motif_counts = vec![0; motifs.len()];
-    for motif in motifs.iter() {
-        let mut start = 0;
-        while let Some(index) = repeats[start..].find(motif) {
-            motif_counts[motifs.iter().position(|x| x == motif).unwrap()] += 1;
-            start += index + motif.len();
-        }
-    }
-    motif_counts.iter().map(|count| count.to_string()).collect::<Vec<String>>().join("_")
-}
-
+     let mut motif_counts = vec![0; motifs.len()];
+     for motif in motifs.iter() {
+         let mut start = 0;
+         while let Some(index) = repeats[start..].find(motif) {
+             motif_counts[motifs.iter().position(|x| x == motif).unwrap()] += 1;
+             start += index + motif.len();
+         }
+     }
+     motif_counts.iter().map(|count| count.to_string()).collect::<Vec<String>>().join("_")
+ }
 
 #[cfg(test)]
 mod tests {
@@ -32,11 +31,22 @@ mod tests {
             "(CAG)4(CGG)3(CAG)3"
         );
     }
+    #[test]
     fn test_create_mc() {
         let motifs = "ATG,CGT,GCA";
         let repeat = "ATGCGTATGCGTAGCGT";
+        println!("{:?}", create_mc(&motifs, &repeat));
         assert_eq!(
-            create_mc(&motifs, repeat), "3_1_0"
+            create_mc(&motifs, repeat), "2_3_0"
+        );
+    }
+    #[test]
+    fn test_create_mc_with_n() {
+        let motifs = "NCG";
+        let repeat = "ACGACGACGACG";
+
+        assert_eq!(
+            create_mc(&motifs, repeat), "4"
         );
     }
 }

--- a/src/motif.rs
+++ b/src/motif.rs
@@ -5,6 +5,21 @@ fn create_motif(seq: &str) -> String {
     unimplemented!()
 }
 
+pub fn create_mc(motifs_string: &str, repeats: &str) -> String {
+    let motifs: Vec<String> = motifs_string.split(',').map(|s| s.to_string()).collect();
+
+    let mut motif_counts = vec![0; motifs.len()];
+    for motif in motifs.iter() {
+        let mut start = 0;
+        while let Some(index) = repeats[start..].find(motif) {
+            motif_counts[motifs.iter().position(|x| x == motif).unwrap()] += 1;
+            start += index + motif.len();
+        }
+    }
+    motif_counts.iter().map(|count| count.to_string()).collect::<Vec<String>>().join("_")
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -15,6 +30,13 @@ mod tests {
         assert_eq!(
             create_motif("CAGCAGCAGCAGCGGCGGCGGCAGCAGCAG"),
             "(CAG)4(CGG)3(CAG)3"
+        );
+    }
+    fn test_create_mc() {
+        let motifs = "ATG,CGT,GCA";
+        let repeat = "ATGCGTATGCGTAGCGT";
+        assert_eq!(
+            create_mc(&motifs, repeat), "3_1_0"
         );
     }
 }

--- a/src/parse_bam.rs
+++ b/src/parse_bam.rs
@@ -144,6 +144,7 @@ fn test_get_overlapping_reads() {
         start: 154654404,
         end: 154654432,
         id: "TEST".to_string(),
+        motifs: "CA".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -159,6 +160,7 @@ fn test_get_overlapping_reads_url1() {
         start: 154654404,
         end: 154654432,
         id: "TEST".to_string(),
+        motifs: "CA".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -174,6 +176,7 @@ fn test_get_overlapping_reads_url2() {
         start: 154654404,
         end: 154654432,
         id: "TEST".to_string(),
+        motifs: "CA".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -189,6 +192,7 @@ fn test_get_overlapping_reads_url3() {
         start: 154654404,
         end: 154654432,
         id: "TEST".to_string(),
+        motifs: "CA".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -204,6 +208,7 @@ fn test_get_overlapping_reads_url4() {
         start: 154654404,
         end: 154654432,
         id: "TEST".to_string(),
+        motifs: "CA".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);

--- a/src/parse_bam.rs
+++ b/src/parse_bam.rs
@@ -143,6 +143,7 @@ fn test_get_overlapping_reads() {
         chrom: String::from("chr7"),
         start: 154654404,
         end: 154654432,
+        id: "TEST".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -157,6 +158,7 @@ fn test_get_overlapping_reads_url1() {
         chrom: String::from("chr20"),
         start: 154654404,
         end: 154654432,
+        id: "TEST".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -171,6 +173,7 @@ fn test_get_overlapping_reads_url2() {
         chrom: String::from("chr20"),
         start: 154654404,
         end: 154654432,
+        id: "TEST".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -185,6 +188,7 @@ fn test_get_overlapping_reads_url3() {
         chrom: String::from("chr20"),
         start: 154654404,
         end: 154654432,
+        id: "TEST".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
@@ -199,6 +203,7 @@ fn test_get_overlapping_reads_url4() {
         chrom: String::from("chr20"),
         start: 154654404,
         end: 154654432,
+        id: "TEST".to_string(),
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);

--- a/src/phase_insertions.rs
+++ b/src/phase_insertions.rs
@@ -332,6 +332,7 @@ mod tests {
                 chrom: "chr7".to_string(),
                 start: 154654404,
                 end: 154654432,
+                id: "TEST".to_string(),
             },
             false,
         );
@@ -372,6 +373,7 @@ mod tests {
                 chrom: "chr7".to_string(),
                 start: 154654404,
                 end: 154654432,
+                id: "TEST".to_string(),
             },
             false,
         );
@@ -411,6 +413,7 @@ mod tests {
                 chrom: "chr7".to_string(),
                 start: 154654404,
                 end: 154654432,
+                id: "TEST".to_string(),
             },
             false,
         );
@@ -453,6 +456,7 @@ mod tests {
                 chrom: "chr7".to_string(),
                 start: 154654404,
                 end: 154654432,
+                id: "TEST".to_string(),
             },
             false,
         );
@@ -493,6 +497,7 @@ mod tests {
                 chrom: "chr7".to_string(),
                 start: 154654404,
                 end: 154654432,
+                id: "TEST_RFC1".to_string(),
             },
             false,
         );
@@ -564,6 +569,7 @@ mod tests {
                 chrom: "chr7".to_string(),
                 start: 154654404,
                 end: 154654432,
+                id: "TEST_RFC1".to_string(),
             },
             false,
         );

--- a/src/phase_insertions.rs
+++ b/src/phase_insertions.rs
@@ -333,6 +333,7 @@ mod tests {
                 start: 154654404,
                 end: 154654432,
                 id: "TEST".to_string(),
+                motifs: "CA".to_string(),
             },
             false,
         );
@@ -374,6 +375,7 @@ mod tests {
                 start: 154654404,
                 end: 154654432,
                 id: "TEST".to_string(),
+                motifs: "CA".to_string(),
             },
             false,
         );
@@ -414,6 +416,7 @@ mod tests {
                 start: 154654404,
                 end: 154654432,
                 id: "TEST".to_string(),
+                motifs: "CA".to_string(),
             },
             false,
         );
@@ -457,6 +460,7 @@ mod tests {
                 start: 154654404,
                 end: 154654432,
                 id: "TEST".to_string(),
+                motifs: "CA".to_string(),
             },
             false,
         );
@@ -498,6 +502,7 @@ mod tests {
                 start: 154654404,
                 end: 154654432,
                 id: "TEST_RFC1".to_string(),
+                motifs: "CA".to_string(),
             },
             false,
         );
@@ -570,6 +575,7 @@ mod tests {
                 start: 154654404,
                 end: 154654432,
                 id: "TEST_RFC1".to_string(),
+                motifs: "CA".to_string(),
             },
             false,
         );

--- a/src/repeats.rs
+++ b/src/repeats.rs
@@ -123,7 +123,6 @@ impl RepeatInterval {
         let chrom = rec.chrom().to_string();
         let start = rec.start().try_into().unwrap();
         let end = rec.end().try_into().unwrap();
-        // TODO: Should be ID
         let mut id = String::new();
         let mut motifs = String::new();
         if let Some(info) = rec.name() {

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -309,6 +309,12 @@ pub fn write_vcf_header(fasta: &str, bam: &str, sample: &Option<String>) {
         println!(r#"##contig=<ID={},length={}>"#, name, length);
     }
     println!(
+        r#"##INFO=<ID=REPID,Number=1,Type=String,Description="Repeat ID">"#
+    );
+    println!(
+        r#"##INFO=<ID=MOTIFS,Number=1,Type=String,Description="Repeat motifs">"#
+    );
+    println!(
         r#"##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the repeat interval">"#
     );
     println!(

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -94,6 +94,7 @@ impl VCFRecord {
         );
         let mc1 = create_mc(&repeat.motifs, &allele1.seq);
         let mc2 = create_mc(&repeat.motifs, &allele2.seq);
+        println!("{:?} {:?} {:?} {:?} {:?} {:?}", &repeat, &repeat.motifs, &mc1, &mc2, &allele1.seq, &allele2.seq);
         // if the consensus is very similar to the reference the variant is considered ref
         // for this I use a threshold of 5% of the length of the repeat sequence in the reference
         // e.g. if the repeat is 300bp in the reference this will allow an edit distance of 15

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -338,7 +338,7 @@ pub fn write_vcf_header(fasta: &str, bam: &str, sample: &Option<String>) {
     );
     println!(r#"##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set identifier">"#);
     println!(r#"##FORMAT=<ID=SUP,Number=2,Type=Integer,Description="Read support per allele">"#);
-    println!(r#"##FORMAT=<ID=MC,Number=2,Type=Integer,Description="Motif count per allele">"#);
+    println!(r#"##FORMAT=<ID=MC,Number=2,Type=String,Description="Motif count per allele">"#);
     println!(r#"##FORMAT=<ID=SC,Number=2,Type=Integer,Description="Consensus score per allele">"#);
     let name = match sample {
         Some(name) => name,

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -7,6 +7,8 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::io::Read;
 
+use crate::motif::create_mc;
+
 pub struct Allele {
     pub length: String, // length of the consensus sequence minus the length of the repeat sequence
     pub full_length: String, // length of the consensus sequence
@@ -55,6 +57,9 @@ pub struct VCFRecord {
     pub ps: Option<u32>, // phase set identifier
     pub flags: String,
     pub allele: (String, String),
+    pub id: String,
+    pub motifs: String,
+    pub mc: (String, String),
 }
 
 impl VCFRecord {
@@ -87,6 +92,8 @@ impl VCFRecord {
             "Genotyping {repeat}:{repeat_ref_sequence} with {} and {}",
             allele1.seq, allele2.seq,
         );
+        let mc1 = create_mc(&repeat.motifs, &allele1.seq);
+        let mc2 = create_mc(&repeat.motifs, &allele2.seq);
         // if the consensus is very similar to the reference the variant is considered ref
         // for this I use a threshold of 5% of the length of the repeat sequence in the reference
         // e.g. if the repeat is 300bp in the reference this will allow an edit distance of 15
@@ -158,6 +165,9 @@ impl VCFRecord {
             ps,
             flags,
             allele: (genotype1.to_string(), genotype2.to_string()),
+            id: repeat.id.clone(),
+            motifs: repeat.motifs.clone(),
+            mc: (mc1, mc2),
         }
     }
 
@@ -182,6 +192,9 @@ impl VCFRecord {
             ps: None,
             flags: "".to_string(),
             allele: (".".to_string(), ".".to_string()),
+            id: repeat.id.clone(),
+            motifs: repeat.motifs.clone(),
+            mc: (".".to_string(), ".".to_string()),
         }
     }
 }
@@ -191,12 +204,12 @@ impl fmt::Display for VCFRecord {
         match &self.alt_seq {
             Some(alts) => {
                 let (FORMAT, ps) = match self.ps {
-                    Some(ps) => ("GT:RB:FRB:SUP:SC:PS", format!(":{}", ps)),
-                    None => ("GT:RB:FRB:SUP:SC", "".to_string()),
+                    Some(ps) => ("GT:RB:FRB:SUP:MC:SC:PS", format!(":{}", ps)),
+                    None => ("GT:RB:FRB:SUP:MC:SC", "".to_string()),
                 };
                 write!(
                     f,
-                    "{chrom}\t{start}\t.\t{ref}\t{alt}\t.\t.\t{flags}END={end};STDEV={sd1},{sd2}{somatic}{outliers}\t{FORMAT}\t{genotype1}|{genotype2}:{l1},{l2}:{fl1},{fl2}:{sup1},{sup2}:{score1},{score2}{ps}",
+                    "{chrom}\t{start}\t.\t{ref}\t{alt}\t.\t.\t{flags}REPID={id};MOTIFS={motifs};END={end};STDEV={sd1},{sd2}{somatic}{outliers}\t{FORMAT}\t{genotype1}|{genotype2}:{l1},{l2}:{fl1},{fl2}:{sup1},{sup2}:{mc1},{mc2}:{score1},{score2}{ps}",
                     chrom = self.chrom,
                     start = self.start,
                     flags = self.flags,
@@ -217,12 +230,17 @@ impl fmt::Display for VCFRecord {
                     sup2 = self.support.1,
                     score1 = self.score.0,
                     score2 = self.score.1,
+                    id = self.id,
+                    motifs = self.motifs,
+                    mc1 = self.mc.0,
+                    mc2 = self.mc.1,
+                    
                 )
             }
             None => {
                 write!(
                     f,
-                    "{chrom}\t{start}\t.\t{ref}\t.\t.\t.\tEND={end};{somatic}\tGT:SUP\t{genotype1}|{genotype2}:{sup1},{sup2}",
+                    "{chrom}\t{start}\t.\t{ref}\t.\t.\t.\tREPID={id};MOTIFS={motifs};END={end};{somatic}\tGT:SUP\t{genotype1}|{genotype2}:{sup1},{sup2}:{mc1},{mc2}",
                     chrom = self.chrom,
                     start = self.start,
                     end = self.end,
@@ -232,6 +250,10 @@ impl fmt::Display for VCFRecord {
                     genotype2 = self.allele.1,
                     sup1 = self.support.0,
                     sup2 = self.support.1,
+                    id = self.id,
+                    motifs = self.motifs,
+                    mc1 = self.mc.0,
+                    mc2 = self.mc.1,
                 )
             }
         }
@@ -310,6 +332,7 @@ pub fn write_vcf_header(fasta: &str, bam: &str, sample: &Option<String>) {
     );
     println!(r#"##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set identifier">"#);
     println!(r#"##FORMAT=<ID=SUP,Number=2,Type=Integer,Description="Read support per allele">"#);
+    println!(r#"##FORMAT=<ID=MC,Number=2,Type=Integer,Description="Motif count per allele">"#);
     println!(r#"##FORMAT=<ID=SC,Number=2,Type=Integer,Description="Consensus score per allele">"#);
     let name = match sample {
         Some(name) => name,


### PR DESCRIPTION
Adds ID, motifs, and motif counts to the output VCF:

`
chr4    39348424        .       AAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGA       AAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAG,AAAAAGAAAAGAAAAGAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAGAAAAG .       .       REPID=RFC1;MOTIFS=AAAAG,AAAGG,AAGGG,AAGAG,AGAGG,AACGG,GGGAC,AAAGGG;END=39348479;STDEV=2,7       GT:RB:FRB:SUP:MC:SC      1|2:6,520:61,575:17,14:12_0_0_0_0_0_0_0,114_0_0_0_0_0_0_0:183,1725
`