### PR TITLE
Updates STRchive URL

### DIFF
--- a/src/repeats.rs
+++ b/src/repeats.rs
@@ -53,7 +53,7 @@ impl RepeatIntervalIterator {
     }
 
     pub fn pathogenic(fasta: &str) -> Self {
-        let url = "https://raw.githubusercontent.com/hdashnow/STRchive/main/data/hg38.STRchive-disease-loci.TRGT.bed";
+        let url = "https://github.com/dashnowlab/STRchive/raw/refs/heads/main/data/STRchive-disease-loci.hg38.TRGT.bed";
         let resp = reqwest::blocking::get(url).expect("request to STRchive failed");
         let body = resp.text().expect("body invalid");
         let mut reader = io::BufReader::new(body.as_bytes());


### PR DESCRIPTION
Closes #8.
Updated URL to STRchive to restore functionality of `--pathogenic`

One caveat: It does not work with the provided fasta of chr7 because the STRchive BED contains more than chr7. So to test, you need a complete copy of hg38.