### PR TITLE
Count each read once, and pool haploid reads regardless of HP tags

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -251,7 +251,9 @@ fn collect_reads(
             record.seq().as_bytes()
         };
 
-        if args.unphased {
+        // a --haploid chromosome has a single haplotype, so its reads are pooled in phase 0
+        // regardless of any HP tags they carry - that is where the genotyper looks for them
+        if args.unphased || crate::vcf::chrom_is_haploid(args, &repeat.chrom) {
             reads.phase0.push(seq);
         } else {
             match parse_bam::get_phase(record) {

--- a/src/genotype.rs
+++ b/src/genotype.rs
@@ -337,19 +337,9 @@ pub fn genotype_with_extracted_reads(
     let mut dbscan_rb: Option<String> = None;
 
     // alignments can be extracted in an unphased manner, if the chromosome is --haploid or the --unphased is set
-    let unphased = (args.haploid.is_some()
-        && args.haploid.as_ref().unwrap().contains(&repeat.chrom))
-        || args.unphased;
+    let unphased = crate::vcf::chrom_is_haploid(args, &repeat.chrom) || args.unphased;
 
-    if args.haploid.is_some()
-        && args
-            .haploid
-            .as_ref()
-            .unwrap()
-            .split(',')
-            .collect::<Vec<&str>>()
-            .contains(&repeat.chrom.as_str())
-    {
+    if crate::vcf::chrom_is_haploid(args, &repeat.chrom) {
         // Haploid chromosome
         let seq = &reads.phase0;
         debug!("{repeat}: Haploid: Aligning {} reads", seq.len());
@@ -551,9 +541,7 @@ fn genotype_repeat(
 
     // alignments can be extracted in an unphased manner, if the chromosome is --haploid or the --unphased is set
     // this means that --haploid overrides the phases which could be present in the bam file
-    let unphased = (args.haploid.is_some()
-        && args.haploid.as_ref().unwrap().contains(&repeat.chrom))
-        || args.unphased;
+    let unphased = crate::vcf::chrom_is_haploid(args, &repeat.chrom) || args.unphased;
 
     // Check for quick reference (0|0), no coverage (.|.), or needs alignment
     // If alignment_all is set, disable quick reference check (set to 0)
@@ -651,15 +639,7 @@ fn genotype_repeat(
     // Either the reads are from a haploid chromosome, unphased or phased by a tool like WhatsHap/hiphase/...
     // A chromosome being haploid overrides the other options, including if the alignments were phased by a tool
 
-    if args.haploid.is_some()
-        && args
-            .haploid
-            .as_ref()
-            .unwrap()
-            .split(',')
-            .collect::<Vec<&str>>()
-            .contains(&repeat.chrom.as_str())
-    {
+    if crate::vcf::chrom_is_haploid(args, &repeat.chrom) {
         // if the chromosome is haploid, all reads were put in phase 0
         let seq = &reads.phase0;
         debug!("{repeat}: Haploid: Aligning {} reads", seq.len());
@@ -878,7 +858,15 @@ fn find_insertions(
             continue;
         }
         let mapping = aligner.map(s.as_slice(), true, false, None, None, None).unwrap_or_else(|err| panic!("Unable to align read with seq {s:?} to repeat-compressed reference for {repeat}\n{err}", s=s.to_ascii_uppercase()));
+        // A read can align to the artificial reference more than once, which happens a lot
+        // in segmental duplications. Only the primary alignment is this read's observation
+        // of the allele: taking the others too would count one read several times towards
+        // read support and the minimum support threshold, and feed near-duplicate sequences
+        // to the clustering and the consensus.
         for read in mapping {
+            if !read.is_primary {
+                continue;
+            }
             if let Some(s) = parse_cs(read, minlen, flanking, repeat) {
                 // slice out inserted sequences from the CS tag
                 insertions.push(s.to_uppercase())


### PR DESCRIPTION
Two independent read-accounting bugs, both pre-existing and both found while working on `--mode fast`.

## Closes #19 — a multi-mapped read counted as several reads

`find_insertions` kept every alignment minimap2 returned for a read. A read that maps to the artificial reference more than once — common in segmental duplications, which is also where this path is slowest — contributed several entries to `insertions`, each counting as a separate read towards `SUP`, the `--support` threshold, the haplotype clustering and the consensus.

At chr1:20003662-20003670, a locus with 17 HP=1 and 17 HP=2 spanning reads, `SUP` was reported as `25,25`. Taking only the primary alignment gives `17,17`.

Across 300 catalog loci this removes 914 duplicate observations (median 2 per locus, up to 59). Nine of those 300 loci change genotype as a result, in both directions — at chr1:20147596 the support was `30,38` of which more than half were duplicates — and none becomes a missing genotype. On the 82 STRchive loci, 159 duplicates disappear and 26 loci see `MRL` change.

## Closes #21 — `--haploid` silently dropped HP-tagged reads

`collect_reads` routed reads by HP tag whenever `--unphased` was not set, but the genotyper reads a haploid chromosome's reads from `phase0`. On a haploid chromosome in a BAM that carries HP tags, every tagged read was therefore dropped. Using chr1 as a stand-in haploid chromosome, a locus with 26 usable reads was genotyped from 9.

While there: `genotype_repeat` and `genotype_with_extracted_reads` tested for a haploid chromosome with a raw substring match on the `--haploid` string, so `--haploid chr10` also made chr1 haploid. All four call sites now use `vcf::chrom_is_haploid`, which splits on commas.

## Scope

`--mode fast` output is byte-identical over 2000 loci; it never used `find_insertions`, and it now benefits from the same haploid routing fix.