### PR TITLE
Add --mapq, and fix the one-base offset in RB and MRL (v0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to STRdust are documented here.
 
+## [0.21.0]
+
+### Changed (breaking)
+
+- **`RB` and `MRL` are one base lower than before.** Both were computed against
+  `end - start`, but the annotated repeat (1-based inclusive start, BED end) spans
+  `end - start + 1` reference bases - the same length as the `REF` sequence in the
+  record. Every `RB` and `MRL` value STRdust has produced was therefore one too high,
+  and `RB` did not equal `FRB - len(REF)` as its header description implies. Both now
+  derive from the `REF` sequence itself. `DBSCAN_RB` carried the same offset and is
+  fixed with them. `FRB` (the raw consensus length) is unaffected.
+  **Downstream impact:** any threshold on `RB` or `MRL`, and any comparison of values
+  across STRdust versions, shifts by one base.
+
+### Added
+
+- `--mapq` (default 10) sets the minimum mapping quality of a read to be used, and is
+  applied consistently in both the batched and non-batched paths. Previously only reads
+  with mapping quality 0 were dropped, and only in the non-batched path, so the batched
+  path - which is what runs for every locus with coverage - applied no filter at all.
+  Pass `--mapq 0` to keep ambiguously mapped reads, which can matter in segmental
+  duplications.
+
+### Notes
+
+- Reads that merely overlap a locus, rather than spanning it, are still used by the
+  `sensitive` path: re-aligning them to the repeat-compressed reference is part of how
+  it recovers alleles the original alignment placed badly. `--mode fast` cannot use them
+  and drops them, falling back to `sensitive` when too few reads are left.
+
 ## [0.20.0]
 
 ### Changed (breaking)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "STRdust"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bio",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "STRdust"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ SPECIFY ONE OF:
 OPTIONS:
     -m, --minlen <MINLEN>              minimal length of insertion/deletion operation [default: 1]
     -s, --support <SUPPORT>            minimal number of supporting reads per haplotype [default: 3]
+        --mapq <MAPQ>                  minimum mapping quality of a read to be used [default: 10]
     -t, --threads <THREADS>            Number of parallel threads to use [default: 1]
         --sample <SAMPLE>              Sample name to use in VCF header, if not provided, the bam file name is used
         --somatic                      Print information on somatic variability

--- a/src/call.rs
+++ b/src/call.rs
@@ -58,6 +58,12 @@ fn process_batch(
             )
         })?;
 
+        // a poorly mapped read is dropped here rather than at genotyping time, so it does
+        // not count towards a target's QUICKREF verdict either
+        if record_rc.mapq() < args.mapq {
+            continue;
+        }
+
         let read_start = record_rc.reference_start() as u32;
         let read_end = record_rc.reference_end() as u32;
 

--- a/src/genotype.rs
+++ b/src/genotype.rs
@@ -102,7 +102,9 @@ fn dbscan_qc_comparison(
         }
     }
 
-    let ref_len = (repeat.end - repeat.start) as i32;
+    // the annotated repeat spans end - start + 1 reference bases (1-based inclusive start,
+    // BED end), the same length as the REF sequence in the record
+    let ref_len = (repeat.end - repeat.start + 1) as i32;
     let dbscan_rb = dbscan_consenses
         .iter()
         .map(|c| match &c.seq {
@@ -157,10 +159,17 @@ fn check_quick_reference_and_collect_reads(
     quick_ref_reads: usize,
     unphased: bool,
     max_number_reads: isize,
+    min_mapq: u8,
 ) -> ReadCheckResult {
     // If quick check disabled, fetch reads normally
     if quick_ref_reads == 0 {
-        return match parse_bam::get_overlapping_reads(bam, repeat, unphased, max_number_reads) {
+        return match parse_bam::get_overlapping_reads(
+            bam,
+            repeat,
+            unphased,
+            max_number_reads,
+            min_mapq,
+        ) {
             Some(reads) => ReadCheckResult::NeedsAlignment(reads),
             None => ReadCheckResult::NoCoverage,
         };
@@ -188,8 +197,8 @@ fn check_quick_reference_and_collect_reads(
             Err(_) => continue,
         };
 
-        // Skip low quality reads or reads that don't fully span
-        if r.mapq() == 0
+        // Skip poorly mapped reads or reads that don't fully span
+        if r.mapq() < min_mapq
             || r.reference_start() > repeat.start.into()
             || r.reference_end() < repeat.end.into()
         {
@@ -555,6 +564,7 @@ fn genotype_repeat(
         quick_ref_reads,
         unphased,
         args.max_number_reads,
+        args.mapq,
     );
 
     // Handle no coverage case early - skip all expensive operations
@@ -1014,7 +1024,7 @@ mod tests {
         let repeat_compressed_reference = repeat.make_repeat_compressed_sequence(&fasta, flanking);
         let mut bam = parse_bam::create_bam_reader(&bam, &fasta);
         let binding =
-            crate::parse_bam::get_overlapping_reads(&mut bam, &repeat, unphased, 60).unwrap();
+            crate::parse_bam::get_overlapping_reads(&mut bam, &repeat, unphased, 60, 10).unwrap();
         let read = binding.phase1.first().expect("No reads found");
         let aligner = minimap2::Aligner::builder()
             .map_ont()
@@ -1050,6 +1060,7 @@ mod tests {
             pathogenic: false,
             minlen: 1,
             support: 1,
+            mapq: 10,
             somatic: false,
             unphased: false,
             find_outliers: false,
@@ -1088,6 +1099,7 @@ mod tests {
             pathogenic: false,
             minlen: 1,
             support: 1,
+            mapq: 10,
             somatic: false,
             unphased: true,
             find_outliers: false,
@@ -1120,6 +1132,7 @@ mod tests {
             pathogenic: false,
             minlen: 1,
             support: 1,
+            mapq: 10,
             somatic: false,
             unphased: true,
             find_outliers: false,
@@ -1158,6 +1171,7 @@ mod tests {
             pathogenic: false,
             minlen: 1,
             support: 1,
+            mapq: 10,
             somatic: true,
             unphased: false,
             find_outliers: false,
@@ -1202,6 +1216,7 @@ mod tests {
             pathogenic: false,
             minlen: 1,
             support: 1,
+            mapq: 10,
             somatic: true,
             // this sample is aligned without HP tags, so only the unphased path returns reads
             unphased: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,11 @@ pub struct Cli {
     #[arg(short, long, default_value_t = 3)]
     support: usize,
 
+    /// Minimum mapping quality of a read to be used. Lower it (down to 0) to keep
+    /// ambiguously mapped reads, which matters in segmental duplications
+    #[arg(long, default_value_t = 10)]
+    mapq: u8,
+
     /// Number of parallel threads to use
     #[arg(short, long, default_value_t = 1)]
     threads: usize,

--- a/src/parse_bam.rs
+++ b/src/parse_bam.rs
@@ -394,6 +394,7 @@ pub fn get_overlapping_reads(
     repeat: &crate::repeats::RepeatInterval,
     unphased: bool,
     max_number_reads: isize,
+    min_mapq: u8,
 ) -> Option<Reads> {
     let tid = bam
         .header()
@@ -415,8 +416,8 @@ pub fn get_overlapping_reads(
     // extract sequences spanning the repeat locus
     for r in bam.rc_records() {
         let r = r.unwrap_or_else(|err| panic!("Error reading BAM file in region {repeat}:\n{err}"));
-        // skip reads with mapq 0 or reads that do not span the repeat locus
-        if r.mapq() == 0
+        // skip poorly mapped reads and reads that do not span the repeat locus
+        if r.mapq() < min_mapq
             || r.reference_start() > repeat.start.into()
             || r.reference_end() < repeat.end.into()
         {
@@ -513,7 +514,7 @@ fn test_get_overlapping_reads() {
     };
     let unphased = false;
     let mut bam = create_bam_reader(&bam, &fasta);
-    let _reads = get_overlapping_reads(&mut bam, &repeat, unphased, 60);
+    let _reads = get_overlapping_reads(&mut bam, &repeat, unphased, 60, 10);
 }
 
 #[test]
@@ -535,7 +536,7 @@ fn test_get_overlapping_reads_url() {
     // this sample is aligned without HP tags, so only the unphased path returns reads
     let unphased = true;
     let mut bam = create_bam_reader(&bam, &fasta);
-    let reads = get_overlapping_reads(&mut bam, &repeat, unphased, 60)
+    let reads = get_overlapping_reads(&mut bam, &repeat, unphased, 60, 10)
         .expect("Expected spanning reads from the remote CRAM");
     // the locus had 20 spanning MAPQ60 reads when this test was written; assert loosely
     // so a re-release of the file upstream does not break the test

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -19,8 +19,13 @@ pub struct Allele {
 }
 
 impl Allele {
-    pub fn from_consensus(consensus: Consensus, start: u32, end: u32) -> Allele {
-        let ref_len = (end - start) as i32;
+    /// `ref_len` is the length of the REF sequence written to the record, i.e. of the
+    /// annotated repeat in the reference. Taking it from the sequence itself rather than
+    /// recomputing it from the coordinates keeps `RB` and `MRL` consistent with `FRB` and
+    /// `REF`: the interval is 1-based inclusive start to BED end, so it spans
+    /// `end - start + 1` bases, and deriving `end - start` made both fields one too high.
+    pub fn from_consensus(consensus: Consensus, ref_len: usize) -> Allele {
+        let ref_len = ref_len as i32;
         match consensus.seq {
             Some(seq) => Allele {
                 length: (seq.len() as i32 - ref_len).to_string(),
@@ -99,8 +104,7 @@ impl VCFRecord {
                 consenses
                     .pop()
                     .expect("Failed getting allele1 from consenses"),
-                repeat.start,
-                repeat.end,
+                repeat_ref_sequence.len(),
             );
             (allele1, None)
         } else {
@@ -108,15 +112,13 @@ impl VCFRecord {
                 consenses
                     .pop()
                     .expect("Failed getting allele2 from consenses"),
-                repeat.start,
-                repeat.end,
+                repeat_ref_sequence.len(),
             );
             let allele1 = Allele::from_consensus(
                 consenses
                     .pop()
                     .expect("Failed getting allele1 from consenses"),
-                repeat.start,
-                repeat.end,
+                repeat_ref_sequence.len(),
             );
             (allele1, Some(allele2))
         };
@@ -715,6 +717,7 @@ fn test_write_vcf_header_from_bam() {
         pathogenic: false,
         minlen: 5,
         support: 1,
+        mapq: 10,
         somatic: false,
         unphased: true,
         find_outliers: false,
@@ -745,6 +748,7 @@ fn test_write_vcf_header_from_name() {
         pathogenic: false,
         minlen: 5,
         support: 1,
+        mapq: 10,
         somatic: false,
         unphased: true,
         find_outliers: false,
@@ -763,6 +767,41 @@ fn test_write_vcf_header_from_name() {
         fast_flank: 10,
     };
     write_vcf_header(&args);
+}
+
+#[test]
+fn test_rb_is_full_length_minus_reference_length() {
+    // the annotated repeat spans end - start + 1 reference bases, which is the length of
+    // the REF sequence written to the record; RB and MRL are measured against that
+    let consensus = Consensus {
+        seq: Some("A".repeat(30)),
+        support: 10,
+        std_dev: 1,
+        score: 5,
+        median_length: 28,
+        imprecise: false,
+    };
+    let repeat_ref_sequence = "A".repeat(9); // chr1:1001-1009 in STRdust coordinates
+    let allele = Allele::from_consensus(consensus, repeat_ref_sequence.len());
+    assert_eq!(allele.full_length, "30");
+    assert_eq!(allele.length, "21", "RB must equal FRB - len(REF)");
+    assert_eq!(allele.median_length, "19", "MRL is measured against the same length");
+}
+
+#[test]
+fn test_rb_of_a_reference_length_allele_is_zero() {
+    let repeat_ref_sequence = "CAG".repeat(5); // 15 bases
+    let consensus = Consensus {
+        seq: Some(repeat_ref_sequence.clone()),
+        support: 8,
+        std_dev: 0,
+        score: 1,
+        median_length: repeat_ref_sequence.len(),
+        imprecise: false,
+    };
+    let allele = Allele::from_consensus(consensus, repeat_ref_sequence.len());
+    assert_eq!(allele.length, "0");
+    assert_eq!(allele.median_length, "0");
 }
 
 #[test]


### PR DESCRIPTION
Two output-affecting corrections, so this is a minor version bump with a CHANGELOG entry.

## Closes #20 — `--mapq`, applied in both paths

Mapping-quality filtering was inconsistent: `get_overlapping_reads` dropped only mapping quality 0, and `process_batch` — which is what actually runs for every locus with coverage — filtered nothing at all.

Both now honour `--mapq`, default 10. Per your call, reads that merely *overlap* a locus are still accepted rather than requiring spanning: re-aligning them to the repeat-compressed reference is part of how the sensitive path recovers alleles the original alignment placed badly. `--mapq 0` keeps ambiguously mapped reads for anyone working in segmental duplications.

Effect at a locus with 5 sub-10 MAPQ reads out of 26 (`--unphased`, chr1:20712561-20712570): `SUP` goes `18,3` → `17,3` → `16,3` at `--mapq 0` / `1` / `60`.

## Closes #22 — RB and MRL were one base too high

Both were measured against `end - start`, but the annotated repeat (1-based inclusive start, BED end) spans `end - start + 1` reference bases — the same length as the `REF` sequence written to the record. So `RB` did not equal `FRB - len(REF)`, which is what its header description implies.

They now derive from the `REF` sequence itself rather than recomputing from coordinates, so the arithmetic cannot drift from what is in the record. `DBSCAN_RB` carried the same offset and is fixed with it. `FRB` is unaffected.

## Verification

Over 2000 loci: every one of 3526 alleles moves by exactly `-1` in `RB`, with `FRB` and `ALT` untouched. Five loci additionally change `FRB`/`ALT`, and `--mapq 0` reproduces the previous output at all five — confirming those come from the new mapping-quality default, not from the offset fix.

Two unit tests pin `RB == FRB - len(REF)` and that a reference-length allele reports `RB=0`.

## Downstream impact

Any threshold on `RB` or `MRL`, and any comparison across STRdust versions, shifts by one base. Flagged in the CHANGELOG under "Changed (breaking)" alongside the v0.20.0 haploid note.