### PR TITLE
Fix three VCF conformance issues in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,32 @@ chr1    1435798 .       TGGCGCGGAGCGGCGCGGAGCG  GCTGGCGCGGAGCGGCGCGGA,GCGGGCGCGC
 chr1    57367044        .       AAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAATAAAT     AAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAATAAA,AAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAATAAA        .       .       END=57367125;STDEV=3,0 GT:RB:FRB:SUP:SC 1|2:-9,-34:72,47:17,12:216,141
 ```
 
+### How a record represents the repeat
+
+A STRdust record describes one catalog interval, not a minimal variant:
+
+- `POS`, `END` and `REF` always come from the target interval, never from the reads. The
+  same BED entry therefore yields the same coordinates and the same `REF` in every sample,
+  which is what makes records joinable across a cohort.
+- `REF` and `ALT` carry the **whole repeat sequence**, not a parsimonious left-aligned
+  allele. This is the usual convention among tandem repeat callers, but it means
+  `bcftools norm` will realign most records and move their positions, breaking any join
+  back to the catalog. Compare STRdust output against a truth set on the *unnormalised*
+  records, or normalise both sides.
+- `ALT` may describe bases lying just **outside** `[POS, END]`. Both modes deliberately
+  count indels the aligner placed near, but not inside, the annotated interval, because
+  repeat boundaries in a catalog rarely agree with where an aligner puts an indel (see
+  `--mode` above). The allele *length* is right, but the record is not a strict
+  "replace `REF` at these coordinates with `ALT`" statement, so reconstructing a haplotype
+  from it (`bcftools consensus`) can place those bases up to a few tens of bases off.
+  Read the lengths from `RB`, `FRB` and `MRL` rather than reconstructing from `ALT`.
+- `GT` uses `|` only when the input reads were phased by an external tool, which is also
+  when `PS` is reported. Alleles obtained by clustering unphased reads are written `1/2`:
+  they are two alleles of one genotype, with no phase relationship to anything else. One
+  consequence is that a phased run mixes separators - loci called through the QUICKREF
+  path never fetch reads, so they carry no phase set and are written `0/0`. Those loci are
+  homozygous reference, where phase carries no information either way.
+
 ## Tuning and hardcoded parameters
 
 STRdust was developed while investigating the [pathogenic GOLGA8A repeat expansion](https://www.nature.com/articles/s41588-026-02537-7), and a [benchmark of repeat genotypers](https://www.biorxiv.org/content/10.64898/2026.02.28.708646v1) found it to be the most sensitive of the tested tools for detecting actual pathogenic expansions. Maximising that sensitivity is a priority, and several of the heuristics that support it are intentionally kept as **hardcoded constants** rather than command-line arguments. A parameter is only worth exposing if a user can tell how to tune it, and exposing all of these would inflate the option list without helping most users. Each is defined as a documented constant in the source so it can be changed (and promoted to a CLI argument) if real cohort experience shows a need:

--- a/src/vcf.rs
+++ b/src/vcf.rs
@@ -521,11 +521,21 @@ fn are_alleles_similar(allele1: &str, allele2: &str) -> bool {
 
 impl VCFRecord {
     // GT field: a single allele value on haploid chromosomes ("1"), an allele pair otherwise ("1|0").
+    /// The two alleles are only *phased* when they came from reads a phasing tool had
+    /// already assigned to haplotypes, which is exactly the case where that tool also gave
+    /// us a phase set. Alleles produced by clustering unphased reads are two alleles of one
+    /// genotype and nothing more, so they get the unphased separator: writing `|` there
+    /// would assert a phase relationship with every other variant on the chromosome, which
+    /// is a claim STRdust cannot make.
+    fn genotype_separator(&self) -> &'static str {
+        if self.ps.is_some() { "|" } else { "/" }
+    }
+
     fn genotype_field(&self) -> String {
         if self.haploid {
             self.allele.0.clone()
         } else {
-            format!("{}|{}", self.allele.0, self.allele.1)
+            format!("{}{}{}", self.allele.0, self.genotype_separator(), self.allele.1)
         }
     }
 
@@ -573,7 +583,7 @@ impl fmt::Display for VCFRecord {
             None => {
                 write!(
                     f,
-                    "{chrom}\t{start}\t.\t{ref}\t.\t.\t.\t{flags}END={end};{somatic}\tGT:SUP\t{gt}:{sup}",
+                    "{chrom}\t{start}\t.\t{ref}\t.\t.\t.\t{flags}END={end}{somatic}\tGT:SUP\t{gt}:{sup}",
                     chrom = self.chrom,
                     start = self.start,
                     flags = self.flags,
@@ -609,7 +619,9 @@ impl PartialEq for VCFRecord {
 impl Eq for VCFRecord {}
 
 pub fn write_vcf_header(args: &Cli) {
-    println!(r#"##fileformat=VCFv4.5"#);
+    // STRdust uses nothing beyond VCF 4.2, and declaring the oldest sufficient version
+    // keeps the output readable by tooling that rejects versions it does not know.
+    println!(r#"##fileformat=VCFv4.2"#);
     // get absolute path to fasta file
     let path = std::fs::canonicalize(&args.fasta)
         .unwrap_or_else(|err| panic!("Failed getting absolute path to fasta: {err}"));
@@ -926,12 +938,35 @@ fn test_display_haploid_single_values() {
 
 #[test]
 fn test_display_diploid_pair_values() {
-    // Diploid record: phased GT pair and comma-separated per-allele FORMAT values.
+    // Without a phase set the alleles came from clustering, so the GT is unphased.
     let record = test_record(false, ("1", "0"), Some("ATCATCATC"));
     let line = format!("{record}");
     let sample = line.split('\t').next_back().unwrap();
-    assert_eq!(sample, "1|0:10,20:10,20:10,20:10,20:10,20");
+    assert_eq!(sample, "1/0:10,20:10,20:10,20:10,20:10,20");
     assert!(line.contains("STDEV=10,20"));
+}
+
+#[test]
+fn test_display_phased_record_uses_phased_separator() {
+    // A phase set means a phasing tool assigned the reads to haplotypes, so `|` is earned
+    // and PS is reported alongside it.
+    let mut record = test_record(false, ("1", "2"), Some("ATCATCATC,ATCATC"));
+    record.ps = Some(12345);
+    let line = format!("{record}");
+    let sample = line.split('\t').next_back().unwrap();
+    assert!(sample.starts_with("1|2:"), "expected phased GT, got {sample}");
+    assert!(sample.ends_with(":12345"), "phased records carry PS, got {sample}");
+    assert!(line.contains("GT:RB:FRB:MRL:SUP:SC:PS"));
+}
+
+#[test]
+fn test_info_field_has_no_empty_key() {
+    // A record without an ALT still must not end its INFO field on a bare ';'
+    let record = test_record(false, ("0", "0"), None);
+    let line = format!("{record}");
+    let info = line.split('\t').nth(7).unwrap();
+    assert!(!info.ends_with(';'), "INFO must not end in an empty key: {info}");
+    assert!(info.contains("END=130"));
 }
 
 #[test]


### PR DESCRIPTION
Refs #24 — the issue stays open for the `ALT`-outside-`[POS, END]` question, which is a design decision rather than a bug. These three are unambiguous.

## Bare semicolon in INFO

Records without an ALT ended their INFO field on an empty key:

```
chr1  20017485  .  TTTTTTTTT  .  .  .  QUICKREF;END=20017493;  GT:SUP  0|0:25
```

The format string joined a somatic field that already carries its own leading `;`, and that field is always empty on the no-ALT path. 231 of 2000 records in a typical run — every QUICKREF and missing-genotype record. `bcftools` tolerates it; stricter parsers need not.

## `GT` claimed phasing it did not have

Alleles obtained by *clustering* unphased reads were written `1|2`. Per the spec `|` asserts a phase relationship, and with no `PS` that implies phasing against everything else on the chromosome — a claim STRdust cannot make from clustered reads.

The separator now follows the phase set: `|` when a phasing tool assigned the reads to haplotypes and gave us a `PS`, `/` otherwise.

One visible consequence: a phased run now mixes separators, because QUICKREF loci never fetch reads and so carry no phase set — they are written `0/0` while called records are `0|1`. Those loci are homozygous reference, where phase carries no information either way. If you would rather they matched, the fix is to plumb `PS` through the quick path, which also means extending its `GT:SUP` format; say the word and I will.

## `##fileformat=VCFv4.5` → `4.2`

STRdust uses nothing beyond 4.2. Declaring the newest version risks tooling refusing a version it does not know, for no gain — and 4.4 onwards treats `END` as a computed field, which sits awkwardly with emitting it for non-symbolic alleles. (It is at least consistent: `END == POS + len(REF) - 1` on every record.)

## Verification

Over 2000 loci, phased and unphased: no INFO field ends in `;`, unphased runs use `/` throughout, phased runs use `|` wherever `PS` is reported, and `bcftools view` parses both without complaint. Three unit tests pin the separator rule in both directions and the absence of an empty INFO key.

Separately confirmed while investigating, and worth recording: `bcftools norm -c w` reports **zero REF mismatches** against the genome, there are no duplicate ALT alleles and none identical to REF, and every emitted INFO/FORMAT key is declared in the header.

## README

Adds a "How a record represents the repeat" section: coordinates always come from the target interval (so records join across a cohort), `REF`/`ALT` carry the whole repeat rather than a parsimonious allele — `bcftools norm` realigns 1557 of 2000 records, which will break joins back to the catalog — and `ALT` may describe bases just outside `[POS, END]`, so lengths should be read from `RB`/`FRB`/`MRL` rather than reconstructed from `ALT`.