### PR TITLE
QUICKREF was calling variant loci homozygous reference

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -10,6 +10,12 @@ use std::{io, sync::Mutex};
 
 use crate::{Cli, genotype, parse_bam, utils::check_files_exist};
 
+/// Reads are inspected this far outside the interval when deciding whether a locus is
+/// homozygous reference. An aligner routinely places a repeat's indel a little outside the
+/// annotated boundary, and calling such a locus reference without looking would be a false
+/// negative on exactly the loci STRdust exists to find.
+const QUICKREF_PADDING: u32 = 15;
+
 /// Per-target bookkeeping while scanning a batch: which of the batch's stored records
 /// overlap this target, and whether any of them showed a length difference (QUICKREF).
 struct TargetInfo {
@@ -93,8 +99,8 @@ fn process_batch(
                 if !args.alignment_all && !info.has_variation {
                     let diff = parse_bam::calculate_all_length_diff_from_cigar(
                         &record_rc,
-                        target.start,
-                        target.end,
+                        target.start.saturating_sub(QUICKREF_PADDING),
+                        target.end + QUICKREF_PADDING,
                     );
                     if diff != 0 {
                         info.has_variation = true;

--- a/src/parse_bam.rs
+++ b/src/parse_bam.rs
@@ -7,15 +7,23 @@ use rust_htslib::bam::record::Aux;
 use std::env;
 use url::Url;
 
-/// Calculate length differences from reference for quick reference check
-/// Counts ALL indels/clips regardless of size within the specified region
-/// Used for fast 0|0 detection where even small variants matter
+/// Net length difference from the reference over `[start - 1, end]`, counting every indel
+/// and clip regardless of size. Used to decide whether a locus can be called homozygous
+/// reference without aligning, where even a one-base difference disqualifies it.
+///
+/// `start` is 1-based (as in [`crate::repeats::RepeatInterval`]) while `reference_position`
+/// walks in 0-based coordinates, so the bound is `start - 1`; the comparison is inclusive
+/// at both ends because an aligner overwhelmingly places a repeat's indel on the repeat's
+/// own first base, and excluding the boundary made the check blind to exactly the events it
+/// exists to detect.
 pub fn calculate_all_length_diff_from_cigar(
     record: &rust_htslib::bam::Record,
     start: u32,
     end: u32,
 ) -> i64 {
     let mut length_diff: i64 = 0;
+    // the repeat occupies 0-based [start - 1, end); an indel on either boundary belongs to it
+    let start = start.saturating_sub(1);
     let mut reference_position = record.reference_start() as u32;
 
     for entry in record.cigar().iter() {
@@ -26,18 +34,18 @@ pub fn calculate_all_length_diff_from_cigar(
                 reference_position += *len;
             }
             rust_htslib::bam::record::Cigar::Del(len) => {
-                if start < reference_position && reference_position < end {
+                if start <= reference_position && reference_position <= end {
                     length_diff -= i64::from(*len);
                 }
                 reference_position += *len;
             }
             rust_htslib::bam::record::Cigar::SoftClip(len)
-                if start < reference_position && reference_position < end =>
+                if start <= reference_position && reference_position <= end =>
             {
                 length_diff += i64::from(*len);
             }
             rust_htslib::bam::record::Cigar::Ins(len)
-                if start < reference_position && reference_position < end =>
+                if start <= reference_position && reference_position <= end =>
             {
                 length_diff += i64::from(*len);
             }
@@ -557,6 +565,70 @@ fn test_get_phase() {
         .expect("Failed to read first record from bam");
     let phase = get_phase(&record.unwrap());
     assert_eq!(phase, 2);
+}
+
+#[cfg(test)]
+mod length_diff_tests {
+    use super::*;
+    use rust_htslib::bam::record::{Cigar, CigarString, Record};
+
+    fn record(pos: i64, cigar: Vec<Cigar>) -> Record {
+        let mut rec = Record::new();
+        let query_len: u32 = cigar
+            .iter()
+            .map(|op| match op {
+                Cigar::Match(l)
+                | Cigar::Equal(l)
+                | Cigar::Diff(l)
+                | Cigar::Ins(l)
+                | Cigar::SoftClip(l) => *l,
+                _ => 0,
+            })
+            .sum();
+        let seq = vec![b'A'; query_len as usize];
+        let qual = vec![30u8; query_len as usize];
+        rec.set(b"read", Some(&CigarString(cigar)), &seq, &qual);
+        rec.set_pos(pos);
+        rec
+    }
+
+    // repeat at 1-based 1001-1010, i.e. 0-based [1000, 1010)
+    const START: u32 = 1001;
+    const END: u32 = 1010;
+
+    #[test]
+    fn counts_an_insertion_at_the_first_base_of_the_repeat() {
+        // Aligners overwhelmingly park a repeat's insertion on the repeat's first base.
+        // Missing it here made QUICKREF call such loci homozygous reference.
+        let rec = record(950, vec![Cigar::Match(50), Cigar::Ins(6), Cigar::Match(50)]);
+        assert_eq!(calculate_all_length_diff_from_cigar(&rec, START, END), 6);
+    }
+
+    #[test]
+    fn counts_an_indel_at_the_last_base_of_the_repeat() {
+        let rec = record(950, vec![Cigar::Match(59), Cigar::Ins(4), Cigar::Match(41)]);
+        assert_eq!(calculate_all_length_diff_from_cigar(&rec, START, END), 4);
+        let rec = record(950, vec![Cigar::Match(59), Cigar::Del(4), Cigar::Match(41)]);
+        assert_eq!(calculate_all_length_diff_from_cigar(&rec, START, END), -4);
+    }
+
+    #[test]
+    fn counts_an_indel_in_the_middle_of_the_repeat() {
+        let rec = record(950, vec![Cigar::Match(55), Cigar::Del(3), Cigar::Match(45)]);
+        assert_eq!(calculate_all_length_diff_from_cigar(&rec, START, END), -3);
+    }
+
+    #[test]
+    fn ignores_an_indel_outside_the_window() {
+        let rec = record(950, vec![Cigar::Match(20), Cigar::Ins(9), Cigar::Match(80)]);
+        assert_eq!(calculate_all_length_diff_from_cigar(&rec, START, END), 0);
+    }
+
+    #[test]
+    fn a_clean_read_reports_no_difference() {
+        let rec = record(950, vec![Cigar::Match(100)]);
+        assert_eq!(calculate_all_length_diff_from_cigar(&rec, START, END), 0);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**No — QUICKREF was not reporting `0/0` correctly, and this is the most consequential bug found so far.** On 2000 catalog loci of a 30x ONT sample it fired on 231 loci and **212 of them (92%) are called non-reference by full genotyping**, several with substantial repeat length differences and 20+ supporting reads.

## Mechanism

`calculate_all_length_diff_from_cigar` compared a **1-based** `start` against a **0-based** `reference_position`, with strict `<` at both ends:

```rust
Cigar::Ins(len) if start < reference_position && reference_position < end => ...
```

So the window it actually inspected began two bases into the repeat and stopped one short of its end. Aligners overwhelmingly place a repeat's indel on the repeat's own **first base** — at chr1:20861973 (an 11 base interval) 26 of 46 spanning reads carry an indel at exactly offset 0:

```
('I', 0, 1) x11   ('I', 0, 2) x5   ('I', 0, 3) x4   ('I', 0, 22) x1   ('D', 0, 1) x4  ...
```

None of them were counted, so `has_variation` stayed false and the locus was emitted as `0/0` — with `SUP=.,.`, so nothing downstream could even filter it out. Both modes are affected: QUICKREF runs before either.

The batched path passed the interval unpadded and was fully exposed. The non-batched path pads by ±15, which masked the off-by-one there — which is why this survived. Same pattern as #19/#20/#21: the batched copy is the less careful one.

## Fix and effect

| | QUICKREF fires | false `0/0` |
|---|---|---|
| before | 231 / 1999 | **212** |
| coordinates fixed | 10 / 1999 | 2 |
| \+ ±15 padding in the batched path | **1 / 1999** | **0** |

Genotypes now match a QUICKREF-disabled run at 1998/1999 loci. On the chr7 test data QUICKREF goes from 427/800 loci to 35/800.

## Cost, and a question

The speed QUICKREF was buying was largely fraudulent, and correcting it costs real time, because loci that were wrongly skipped are now genotyped:

- sensitive, 300 loci: 69 s → **91 s** CPU
- fast, 2000 loci: 7.1 s → **9.1 s** CPU

On this catalog QUICKREF now fires on 1 locus in 2000, so it is worth asking whether it still earns its place — a correct version of it is nearly free of benefit on dense STR catalogs, though it may pay off on panels with more genuinely reference loci.

## Not addressed here — three further QUICKREF issues

1. **No minimum read count in the batched path.** The non-batched path requires ≥5 reads checked; the batched one has no guard, so a locus covered by a single read, or only by reads clipping its edge, can still be called `0/0`.
2. **`SUP=.,.`** — a QUICKREF record carries no read support, so a `0/0` backed by 40 reads is indistinguishable from one backed by 1.
3. **Different criteria between the paths** — batched requires `diff == 0` exactly, non-batched allows `|diff| ≤ 3`; and a read with an equal-sized insertion and deletion inside the interval nets to zero and looks reference.

Happy to take any of those in a follow-up; they all change behaviour, so I would rather you pick.